### PR TITLE
Fix ComicDownloadJob silent no-op after first run (missing @StepScope on dateReader)

### DIFF
--- a/comic-engine/src/main/java/org/stapledon/engine/batch/config/ComicRetrievalJobConfig.java
+++ b/comic-engine/src/main/java/org/stapledon/engine/batch/config/ComicRetrievalJobConfig.java
@@ -90,9 +90,11 @@ public class ComicRetrievalJobConfig {
     }
 
     /**
-     * Reader that provides the target date for comic downloads
+     * Reader that provides the target date for comic downloads. Uses @StepScope so the date is captured at job execution time and the underlying ListItemReader is recreated per run.
+     * A singleton ListItemReader would be exhausted after the first execution and silently no-op forever.
      */
     @Bean
+    @StepScope
     public ItemReader<LocalDate> dateReader() {
         LocalDate targetDate = LocalDate.now();
         log.info("Comic download target date: {} ({})", targetDate, targetDate.getDayOfWeek());

--- a/comic-engine/src/test/java/org/stapledon/engine/batch/ComicRetrievalJobConfigTest.java
+++ b/comic-engine/src/test/java/org/stapledon/engine/batch/ComicRetrievalJobConfigTest.java
@@ -13,11 +13,13 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 
+import java.lang.reflect.Method;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -79,5 +81,15 @@ class ComicRetrievalJobConfigTest {
 
         assertThat(results).isEmpty();
         verify(managementFacade).updateComicsForDate(date, sourceFilter);
+    }
+
+    @Test
+    void dateReader_isStepScoped() throws NoSuchMethodException {
+        Method method = ComicRetrievalJobConfig.class.getDeclaredMethod("dateReader");
+
+        assertThat(method.isAnnotationPresent(StepScope.class))
+                .as("dateReader must be @StepScope: without it the singleton ListItemReader is exhausted after the first job run, "
+                        + "and every subsequent ComicDownloadJob silently completes in 1ms with zero downloads")
+                .isTrue();
     }
 }


### PR DESCRIPTION
## Summary

`ComicDownloadJob` has been silently completing in ~1ms with zero downloads on every run after the first one since container start. Investigation of `comics-api-dev` logs (last 7 days) showed the daily 6 AM job firing on schedule, status `COMPLETED`, but the step `comicRetrievalStep` running in **1ms** with no `Processing comics for date:` or `Successfully downloaded:` log lines and no errors.

## Root cause

`comic-engine/src/main/java/org/stapledon/engine/batch/config/ComicRetrievalJobConfig.java#dateReader()` was a Spring **singleton** (no `@StepScope`):

```java
@Bean
public ItemReader<LocalDate> dateReader() {
    LocalDate targetDate = LocalDate.now();
    log.info("Comic download target date: {} ({})", targetDate, targetDate.getDayOfWeek());
    return new ListItemReader<>(List.of(targetDate));
}
```

`ListItemReader` is stateful — once it returns its single item, every subsequent `read()` returns `null`. So:

```mermaid
sequenceDiagram
    participant App as App startup
    participant Bean as dateReader (singleton)
    participant Run1 as Job run 1
    participant RunN as Job runs 2..N
    App->>Bean: instantiate ListItemReader([startup_date])
    Run1->>Bean: read()
    Bean-->>Run1: startup_date (NOT today's date!)
    Run1->>Bean: read()
    Bean-->>Run1: null (exhausted)
    Note over Run1: Run 1 processes the<br/>startup date - wrong, but<br/>at least does something
    RunN->>Bean: read()
    Bean-->>RunN: null (still exhausted)
    Note over RunN: Step completes in 1ms<br/>with 0 items, COMPLETED.<br/>No errors. Silent no-op.
```

Two consequences:

1. **Wrong date even on the first run** — `LocalDate.now()` is evaluated at Spring context startup, not at job execution time.
2. **Silent no-op forever after** — once exhausted, the bean returns no work for every subsequent execution.

The `comics-api-dev` container has been up 6 weeks. The issue has masked itself on every long uptime since deploy/restart "fixes" it for one run.

### Evidence from dev logs

| Date | Event | Notes |
|------|-------|-------|
| 2026-03-24 (startup, `[main]` thread) | `Comic download target date: 2026-03-24 (TUESDAY)` | Logged once, at app startup |
| 2026-03-25 06:00 | `Processing comics for date: 2026-03-24 (TUESDAY, sourceFilter=null)` | Processed startup date, not today |
| 2026-03-26 → 2026-05-06 | step duration `1ms`, no per-comic lines | Reader exhausted; daily job is a no-op |

### Why this wasn't caught earlier

- No errors or exceptions are produced — the step status is `COMPLETED`.
- The `dateReader` factory unit test still passes (calling the factory bypasses Spring's bean-scope semantics).
- The sibling `ComicBackfillJobConfig.backfillTaskReader` already uses `@StepScope` for the same reason and even has a comment explaining the gotcha — it just wasn't applied to `dateReader`.

## Fix

Add `@StepScope` to `dateReader()` so Spring creates a fresh `ListItemReader` (and re-evaluates `LocalDate.now()`) per job execution.

```diff
+@StepScope
 @Bean
 public ItemReader<LocalDate> dateReader() { ... }
```

## Audit of other batch jobs

I audited every `*JobConfig.java` for the same pattern:

| Config | Pattern | Status |
|--------|---------|--------|
| `ComicRetrievalJobConfig` | singleton `ItemReader` (`ListItemReader`) | ❌ **fixed** |
| `ComicBackfillJobConfig` | `@StepScope` reader + documented comment | ✓ already correct |
| `ImageMetadataBackfillJobConfig` | `@StepScope` tasklet | ✓ |
| `RetrievalRecordPurgeJobConfig` | `@StepScope` tasklets | ✓ |
| `MetricsArchiveJobConfig` | stateless tasklet lambda; computes `LocalDate.now()` inside | ✓ |
| `AvatarBackfillJobConfig` | stateless tasklet lambda | ✓ |

`ComicRetrievalJobConfig.dateReader` is the only affected bean.

## Changes

| File | Change |
|------|--------|
| `comic-engine/src/main/java/org/stapledon/engine/batch/config/ComicRetrievalJobConfig.java` | Add `@StepScope` to `dateReader()`; expand Javadoc to explain the lifecycle requirement |
| `comic-engine/src/test/java/org/stapledon/engine/batch/ComicRetrievalJobConfigTest.java` | Add `dateReader_isStepScoped()` regression test asserting the annotation is present, with a description that explains the failure mode if it's removed |

## Test plan

- [x] `./gradlew :comic-engine:test --tests ComicRetrievalJobConfigTest` — all 8 tests pass, including the new annotation assertion
- [x] `./gradlew clean checkstyleMain` — clean
- [x] `./gradlew clean testAll` — green
- [ ] Deploy to dev; trigger `ComicDownloadJob` manually twice in succession via admin UI
- [ ] Verify both runs log `Processing comics for date: <today>` with multi-second duration
- [ ] Verify per-comic `Successfully downloaded:` / `Failed to process:` lines appear
- [ ] Confirm new strips land under today's date in the NFS store

## Out of scope

- Recovering the 6 weeks of missing dev downloads — `ComicBackfillJob` is the right tool for that and is currently paused. Will be a separate task once this fix is deployed.
- The `RunIdIncrementer` change in PR #251 was unrelated to this bug.