### PR TITLE
Tech debt sweep: doc drift, Jackson→Gson, LocalDateTime→OffsetDateTime

### DIFF
--- a/.github/workflows/comic-hub.yml
+++ b/.github/workflows/comic-hub.yml
@@ -5,12 +5,12 @@ on:
     branches: [ "master" ]
     paths:
       - 'comic-hub/**'
-      - '.github/workflows/angular.yml'
+      - '.github/workflows/comic-hub.yml'
   pull_request:
     branches: [ "master" ]
     paths:
       - 'comic-hub/**'
-      - '.github/workflows/angular.yml'
+      - '.github/workflows/comic-hub.yml'
 
 permissions:
   contents: read
@@ -43,4 +43,7 @@ jobs:
     - name: Build production
       run: npm run build
       env:
-        NEXT_PUBLIC_GRAPHQL_ENDPOINT: http://10.0.0.47:8087/graphql
+        # CI builds the static bundle without a real backend; the runtime endpoint is injected
+        # by the deployment, not baked in at build time. Keep this as a placeholder so Next can
+        # resolve the env var without leaking an internal LAN IP into a public workflow file.
+        NEXT_PUBLIC_GRAPHQL_ENDPOINT: http://localhost:8087/graphql

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,6 @@ graph TD
 
     subgraph Frontend
         HUB["comic-hub<br/>Next.js 16 / React 19"]
-        WEB["comic-web<br/>Legacy Angular (being replaced)"]
     end
 
     API --> ENGINE
@@ -27,7 +26,6 @@ graph TD
     ENGINE --> COMMON
     METRICS --> COMMON
     HUB -->|GraphQL + REST| API
-    WEB -->|GraphQL + REST| API
 ```
 
 ## Build Commands
@@ -64,7 +62,7 @@ Each module has its own coding standards. **Module-level standards override this
 
 | Module | Standards | Key Details |
 |--------|-----------|-------------|
-| **comic-api** | [@~/comic-api/CLAUDE.md](comic-api/CLAUDE.md) | GraphQL-first, Gson (not Jackson), NFS filesystem as DB, JWT auth (USER/OPERATOR/ADMIN) |
+| **comic-api** | [@~/comic-api/CLAUDE.md](comic-api/CLAUDE.md) | GraphQL-first, Gson for persisted JSON (Jackson allowed at Spring boundaries), NFS filesystem as DB, JWT auth (USER/OPERATOR/ADMIN) |
 | **comic-hub** | [@~/comic-hub/CLAUDE.md](comic-hub/CLAUDE.md) | Z-index tokens, httpOnly cookie auth, `proxy.ts` (not `middleware.ts`) |
 | **comic-engine** | See [@~/docs/design/architecture.md](docs/design/architecture.md) | Downloaders, facades, Spring Batch jobs |
 | **comic-common** | See [@~/docs/design/architecture.md](docs/design/architecture.md) | Shared DTOs, service interfaces, utilities |
@@ -101,7 +99,6 @@ Full docs live in [@~/docs/README.md](docs/README.md):
 | **API** | [@~/docs/api/overview.md](docs/api/overview.md) (auth, pagination, errors), [@~/docs/api/comics.md](docs/api/comics.md), [@~/docs/api/batch-jobs.md](docs/api/batch-jobs.md) |
 | **Design** | [@~/docs/design/architecture.md](docs/design/architecture.md), [@~/docs/design/batch-jobs.md](docs/design/batch-jobs.md), [@~/docs/design/downloader-strategies.md](docs/design/downloader-strategies.md) |
 | **Storage** | [@~/docs/storage/overview.md](docs/storage/overview.md) (NFS layout, atomic writes), [@~/docs/storage/comic-data.md](docs/storage/comic-data.md) |
-| **UI Refactor** | [@~/docs/2026-ui-refactor/](docs/2026-ui-refactor/) (visual style, component specs, screen layouts) |
 
 ## Debug Utilities
 

--- a/comic-api/CLAUDE.md
+++ b/comic-api/CLAUDE.md
@@ -1,7 +1,7 @@
 # ComicAPI Coding Standards
 
 ## 1. Documentation & Storage
-- **Source of Truth:** All comic metadata resides in JSON files on the NFS filesystem. Treat the filesystem as a "Read-Through Cache." Refer to `STORAGE_DETAILS.md` for schema.
+- **Source of Truth:** All comic metadata resides in JSON files on the NFS filesystem. Treat the filesystem as a "Read-Through Cache." See [@~/docs/storage/overview.md](../docs/storage/overview.md) and [@~/docs/storage/comic-data.md](../docs/storage/comic-data.md) for schema.
 - **No Database:** Do not implement JPA, Hibernate, or any relational database logic.
 - **NFS I/O Safety:** Use `java.nio.file.Path` over `java.io.File`.
 - **Atomic Writes:** When updating JSON metadata, use a "write-to-temp-then-move" pattern to prevent corruption on NFS during network hiccups.
@@ -54,11 +54,12 @@
 - **Binary Data:** GQL handles metadata only. Binary streams stay on REST using `FileSystemResource`.
 - **Authorization:** Three roles — `USER` (default), `OPERATOR` (batch/metrics read-only), `ADMIN` (full access). Schema directives: `@public`, `@authenticated`, `@hasRole(role: "ROLE")`.
 
-## 8. JSON Serialization (Gson)
-- **Gson only.** Do not use Jackson annotations (`@JsonProperty`, `@JsonFormat`).
+## 8. JSON Serialization
+- **Gson is the standard for persisted/domain JSON** — anything written to NFS or read back through `GsonUtils`. Do not use Jackson annotations (`@JsonProperty`, `@JsonFormat`, `@JsonIgnore`) on these DTOs.
+- **Jackson is allowed at Spring framework boundaries only:** actuator endpoints (health/info DTOs) and the generic REST response wrapper (`ApiResponse`). Spring serializes these via its built-in `ObjectMapper`; using Gson there fights the framework.
 - Use `GsonBuilder().registerTypeAdapterFactory(new RecordAdapterFactory())` for Records.
 - Use `@SerializedName` if JSON key differs from Java field name.
-- Use `@Qualifier("gsonWithLocalDate")` bean for date-time serialization.
+- Use `@Qualifier("gsonWithLocalDate")` bean for date-time serialization. Prefer `OffsetDateTimeAdapter` for new code (`LocalDateTimeAdapter` remains for read-back compatibility with legacy JSON files).
 
 ## 9. Lombok Usage
 - `@ToString(onlyExplicitlyIncluded = true)` with `@ToString.Include` on identifier/logging fields.

--- a/comic-api/Dockerfile
+++ b/comic-api/Dockerfile
@@ -1,7 +1,8 @@
 FROM eclipse-temurin:21-jre-alpine
 LABEL MAINTAINER="adrian@gilbert.ca"
 
-RUN addgroup --system --gid 1001 comicapi && \
+RUN apk add --no-cache wget && \
+    addgroup --system --gid 1001 comicapi && \
     adduser --system --uid 1001 comicapi
 
 EXPOSE 8888

--- a/comic-api/src/main/java/org/stapledon/api/dto/health/HealthStatus.java
+++ b/comic-api/src/main/java/org/stapledon/api/dto/health/HealthStatus.java
@@ -1,6 +1,6 @@
 package org.stapledon.api.dto.health;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +28,7 @@ public class HealthStatus {
     /**
      * Current server time when check was performed
      */
-    private LocalDateTime timestamp;
+    private OffsetDateTime timestamp;
 
     /**
      * Application uptime in milliseconds

--- a/comic-api/src/main/java/org/stapledon/api/dto/user/User.java
+++ b/comic-api/src/main/java/org/stapledon/api/dto/user/User.java
@@ -1,6 +1,7 @@
 package org.stapledon.api.dto.user;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -31,9 +32,9 @@ public class User {
     private String displayName;
 
     @Builder.Default
-    private LocalDateTime created = LocalDateTime.now();
+    private OffsetDateTime created = OffsetDateTime.now(ZoneOffset.UTC);
 
-    private LocalDateTime lastLogin;
+    private OffsetDateTime lastLogin;
 
     @Builder.Default
     private List<String> roles = new ArrayList<>();

--- a/comic-api/src/main/java/org/stapledon/api/model/ApiResponse.java
+++ b/comic-api/src/main/java/org/stapledon/api/model/ApiResponse.java
@@ -1,7 +1,8 @@
 package org.stapledon.api.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
-    private LocalDateTime timestamp;
+    private OffsetDateTime timestamp;
     private int status;
     private String message;
     private T data;
@@ -33,7 +34,7 @@ public class ApiResponse<T> {
      */
     public static <T> ApiResponse<T> success(T data) {
         return ApiResponse.<T>builder()
-                .timestamp(LocalDateTime.now())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
                 .status(200)
                 .message("Success")
                 .data(data)
@@ -50,7 +51,7 @@ public class ApiResponse<T> {
      */
     public static <T> ApiResponse<T> success(T data, String message) {
         return ApiResponse.<T>builder()
-                .timestamp(LocalDateTime.now())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
                 .status(200)
                 .message(message)
                 .data(data)
@@ -67,7 +68,7 @@ public class ApiResponse<T> {
      */
     public static <T> ApiResponse<T> error(int status, String message) {
         return ApiResponse.<T>builder()
-                .timestamp(LocalDateTime.now())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
                 .status(status)
                 .message(message)
                 .build();

--- a/comic-api/src/main/java/org/stapledon/api/model/ResponseBuilder.java
+++ b/comic-api/src/main/java/org/stapledon/api/model/ResponseBuilder.java
@@ -58,7 +58,7 @@ public final class ResponseBuilder {
      */
     public static <T> ResponseEntity<ApiResponse<T>> created(T data) {
         ApiResponse<T> response = ApiResponse.<T>builder()
-                .timestamp(java.time.LocalDateTime.now())
+                .timestamp(java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC))
                 .status(HttpStatus.CREATED.value())
                 .message("Resource created successfully")
                 .data(data)

--- a/comic-api/src/main/java/org/stapledon/api/resolver/BatchJobResolver.java
+++ b/comic-api/src/main/java/org/stapledon/api/resolver/BatchJobResolver.java
@@ -305,8 +305,8 @@ public class BatchJobResolver {
                             step.skipCount(),
                             step.commitCount(),
                             step.rollbackCount(),
-                            toOffset(step.startTime()),
-                            toOffset(step.endTime())))
+                            step.startTime(),
+                            step.endTime()))
                     .toList();
         }
 
@@ -314,8 +314,8 @@ public class BatchJobResolver {
                 summary.getExecutionId() != null ? summary.getExecutionId() : 0L,
                 summary.getJobName(),
                 summary.getStatus(),
-                toOffset(summary.getStartTime()),
-                toOffset(summary.getEndTime()),
+                summary.getStartTime(),
+                summary.getEndTime(),
                 durationMs,
                 summary.getExitCode(),
                 summary.getExitMessage(),
@@ -377,7 +377,6 @@ public class BatchJobResolver {
         OffsetDateTime nextRunTime = computeNextRunTime(scheduler);
         OffsetDateTime lastToggled = stateOpt
                 .map(SchedulerStateService.SchedulerState::lastToggled)
-                .map(ldt -> ldt.atZone(ZoneId.of(batchTimezone)).toOffsetDateTime())
                 .orElse(null);
 
         List<BatchJobParameterDto> availableParameters = scheduler.getParameterDefinitions().stream()

--- a/comic-api/src/main/java/org/stapledon/api/service/SystemHealthService.java
+++ b/comic-api/src/main/java/org/stapledon/api/service/SystemHealthService.java
@@ -16,7 +16,8 @@ import org.stapledon.metrics.collector.StorageMetricsCollector;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,7 @@ public class SystemHealthService implements HealthService {
         // Basic health status without detailed metrics
         return HealthStatus.builder()
                 .status(determineStatus())
-                .timestamp(LocalDateTime.now())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
                 .uptime(getUptime())
                 .buildInfo(getBuildInfo())
                 .build();
@@ -56,7 +57,7 @@ public class SystemHealthService implements HealthService {
 
         return HealthStatus.builder()
                 .status(overallStatus)
-                .timestamp(LocalDateTime.now())
+                .timestamp(OffsetDateTime.now(ZoneOffset.UTC))
                 .uptime(getUptime())
                 .buildInfo(getBuildInfo())
                 .systemResources(getSystemResources())

--- a/comic-api/src/main/java/org/stapledon/infrastructure/config/GsonProvider.java
+++ b/comic-api/src/main/java/org/stapledon/infrastructure/config/GsonProvider.java
@@ -3,170 +3,39 @@ package org.stapledon.infrastructure.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.stapledon.common.config.IComicsBootstrap;
+import org.stapledon.common.util.GsonUtils;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
 import java.lang.reflect.Type;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Configuration
 public class GsonProvider {
 
     @Bean(name = "gsonWithLocalDate")
     public Gson gson() {
-        return new GsonBuilder()
-                .setPrettyPrinting()
-                .registerTypeAdapter(LocalDate.class, new LocalDateAdapter())
-                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
-                .registerTypeAdapter(OffsetDateTime.class, new OffsetDateTimeAdapter())
+        return GsonUtils.createGsonBuilder()
                 .registerTypeAdapter(IComicsBootstrap.class, new IComicsBootstrapDeserializer())
                 .create();
     }
 
     /**
-     * Custom deserializer for IComicsBootstrap interface
-     * Determines the concrete implementation based on fields in the JSON
+     * Custom deserializer for IComicsBootstrap interface.
+     * Determines the concrete implementation based on fields in the JSON.
      */
     static class IComicsBootstrapDeserializer implements JsonDeserializer<IComicsBootstrap> {
         @Override
         public IComicsBootstrap deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
                 throws JsonParseException {
             JsonObject jsonObject = json.getAsJsonObject();
-
-            // Determine which implementation to use based on fields present
             if (jsonObject.has("website")) {
-                // If it has a website field, it's a KingComicsBootStrap
                 return context.deserialize(json, KingComicsBootStrap.class);
-            } else {
-                // Otherwise, assume it's a GoComicsBootstrap
-                return context.deserialize(json, GoComicsBootstrap.class);
             }
-        }
-    }
-
-    static class LocalDateAdapter extends TypeAdapter<LocalDate> {
-        @Override
-        public void write(final JsonWriter jsonWriter, final LocalDate localDate) throws IOException {
-            if (localDate == null) {
-                jsonWriter.nullValue();
-            } else {
-                jsonWriter.value(localDate.toString());
-            }
-        }
-
-        /**
-         * Deserialize a LocalDate stored one of three ways:
-         * - Serialized from Local date (Object, w/ 3 fields)
-         * - year
-         * - month
-         * - day
-         * - Serialized as a String (YYYY-MM-DD)
-         * - Null Value
-         *
-         * @param jsonReader - Reader to read the LocalDate from
-         */
-        @Override
-        public LocalDate read(final JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.BEGIN_OBJECT) {
-                int year = 0;
-                int month = 0;
-                int day = 0;
-                jsonReader.beginObject();
-                while (jsonReader.peek() != JsonToken.END_OBJECT) {
-                    var name = jsonReader.nextName();
-                    switch (name) {
-                        case "year":
-                            year = jsonReader.nextInt();
-                            break;
-                        case "month":
-                            month = jsonReader.nextInt();
-                            break;
-                        case "day":
-                            day = jsonReader.nextInt();
-                            break;
-                        default:
-                            throw new IllegalArgumentException(String.format("Unexpected name=%s", name));
-                    }
-                }
-                jsonReader.endObject();
-                return LocalDate.of(year, month, day);
-            } else if (jsonReader.peek() == JsonToken.NULL) {
-                jsonReader.nextNull();
-                return null;
-            } else {
-                return LocalDate.parse(jsonReader.nextString());
-            }
-        }
-    }
-
-    /**
-     * Type adapter for LocalDateTime that handles serialization and deserialization
-     * safely
-     * without accessing internal fields directly.
-     */
-    static class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
-        private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
-        @Override
-        public void write(JsonWriter jsonWriter, LocalDateTime localDateTime) throws IOException {
-            if (localDateTime == null) {
-                jsonWriter.nullValue();
-            } else {
-                jsonWriter.value(FORMATTER.format(localDateTime));
-            }
-        }
-
-        @Override
-        public LocalDateTime read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                jsonReader.nextNull();
-                return null;
-            }
-
-            String dateTimeStr = jsonReader.nextString();
-            return LocalDateTime.parse(dateTimeStr, FORMATTER);
-        }
-    }
-
-    /**
-     * Type adapter for OffsetDateTime that handles serialization and
-     * deserialization
-     * using ISO-8601 format with timezone offset.
-     */
-    static class OffsetDateTimeAdapter extends TypeAdapter<OffsetDateTime> {
-        private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-
-        @Override
-        public void write(JsonWriter jsonWriter, OffsetDateTime offsetDateTime) throws IOException {
-            if (offsetDateTime == null) {
-                jsonWriter.nullValue();
-            } else {
-                jsonWriter.value(FORMATTER.format(offsetDateTime));
-            }
-        }
-
-        @Override
-        public OffsetDateTime read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                jsonReader.nextNull();
-                return null;
-            }
-
-            String dateTimeStr = jsonReader.nextString();
-            return OffsetDateTime.parse(dateTimeStr, FORMATTER);
+            return context.deserialize(json, GoComicsBootstrap.class);
         }
     }
 }

--- a/comic-api/src/main/java/org/stapledon/infrastructure/config/UserConfigWriter.java
+++ b/comic-api/src/main/java/org/stapledon/infrastructure/config/UserConfigWriter.java
@@ -9,7 +9,8 @@ import org.stapledon.common.config.CacheProperties;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParseException;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -94,7 +95,7 @@ public class UserConfigWriter {
                     .passwordHash(hashedPassword)
                     .email(registrationDto.getEmail())
                     .displayName(registrationDto.getDisplayName())
-                    .created(LocalDateTime.now())
+                    .created(OffsetDateTime.now(ZoneOffset.UTC))
                     .roles(new ArrayList<>(List.of("USER")))
                     .build();
 
@@ -146,7 +147,7 @@ public class UserConfigWriter {
             // Verify password
             if (BCrypt.checkpw(password, user.getPasswordHash())) {
                 // Update last login time
-                user.setLastLogin(LocalDateTime.now());
+                user.setLastLogin(OffsetDateTime.now(ZoneOffset.UTC));
                 boolean saved = saveUser(user);
                 if (!saved) {
                     log.warn("Failed to update last login time for user: {}", username);

--- a/comic-api/src/test/java/org/stapledon/api/controller/PureAuthIntegrationTest.java
+++ b/comic-api/src/test/java/org/stapledon/api/controller/PureAuthIntegrationTest.java
@@ -12,7 +12,7 @@ import org.stapledon.api.dto.user.UserRegistrationDto;
 import org.stapledon.infrastructure.config.properties.JwtProperties;
 import org.stapledon.infrastructure.security.JwtTokenUtil;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.UUID;
 import tools.jackson.databind.ObjectMapper;
@@ -45,7 +45,7 @@ class PureAuthIntegrationTest {
                 .passwordHash(passwordEncoder.encode("password123"))
                 .email("jwt@example.com")
                 .displayName("JWT Test User")
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .roles(Collections.singletonList("USER"))
                 .userToken(UUID.randomUUID())
                 .build();

--- a/comic-api/src/test/java/org/stapledon/api/resolver/BatchJobResolverTest.java
+++ b/comic-api/src/test/java/org/stapledon/api/resolver/BatchJobResolverTest.java
@@ -30,6 +30,7 @@ import org.stapledon.engine.batch.scheduler.DailyJobScheduler;
 import org.stapledon.engine.batch.scheduler.SchedulerStateService;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,7 +97,7 @@ class BatchJobResolverTest {
             when(schedulerStateService.isPaused("ComicBackfillJob")).thenReturn(true);
             when(schedulerStateService.getState("ComicDownloadJob")).thenReturn(Optional.empty());
             when(schedulerStateService.getState("ComicBackfillJob"))
-                    .thenReturn(Optional.of(new SchedulerStateService.SchedulerState(true, LocalDateTime.of(2026, 3, 17, 10, 0), "admin")));
+                    .thenReturn(Optional.of(new SchedulerStateService.SchedulerState(true, OffsetDateTime.of(2026, 3, 17, 10, 0, 0, 0, java.time.ZoneOffset.UTC), "admin")));
 
             var resolver = createResolver(List.of(comicDownloadScheduler, comicBackfillScheduler));
             List<BatchSchedulerInfoDto> result = resolver.batchSchedulers();
@@ -228,7 +229,7 @@ class BatchJobResolverTest {
             when(comicDownloadScheduler.getParameterDefinitions()).thenReturn(List.of());
             when(schedulerStateService.isPaused("ComicDownloadJob")).thenReturn(true);
             when(schedulerStateService.getState("ComicDownloadJob"))
-                    .thenReturn(Optional.of(new SchedulerStateService.SchedulerState(true, LocalDateTime.now(), "admin")));
+                    .thenReturn(Optional.of(new SchedulerStateService.SchedulerState(true, OffsetDateTime.now(), "admin")));
 
             var resolver = createResolver(List.of(comicDownloadScheduler));
             ToggleJobSchedulerPayload result = resolver.toggleJobScheduler("ComicDownloadJob", true);

--- a/comic-api/src/test/java/org/stapledon/core/auth/service/JwtAuthServiceTest.java
+++ b/comic-api/src/test/java/org/stapledon/core/auth/service/JwtAuthServiceTest.java
@@ -23,7 +23,7 @@ import org.stapledon.core.user.service.UserService;
 import org.stapledon.infrastructure.security.JwtTokenUtil;
 import org.stapledon.infrastructure.security.JwtUserDetailsService;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -72,7 +72,7 @@ class JwtAuthServiceTest {
                 .passwordHash("hashedPassword")
                 .email("newuser@example.com")
                 .displayName("New User") // Explicit display name that matches test
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .roles(List.of("USER"))
                 .userToken(UUID.randomUUID())
                 .build();
@@ -250,7 +250,7 @@ class JwtAuthServiceTest {
                 .passwordHash("hashedPassword")
                 .email(username + "@example.com")
                 .displayName("Test " + username)
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .roles(List.of("USER"))
                 .userToken(UUID.randomUUID())
                 .build();

--- a/comic-api/src/test/java/org/stapledon/core/user/service/JsonUserServiceTest.java
+++ b/comic-api/src/test/java/org/stapledon/core/user/service/JsonUserServiceTest.java
@@ -11,7 +11,7 @@ import org.stapledon.api.dto.user.User;
 import org.stapledon.api.dto.user.UserRegistrationDto;
 import org.stapledon.infrastructure.config.UserConfigWriter;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -127,7 +127,7 @@ class JsonUserServiceTest {
                 .passwordHash("hashedPassword")
                 .email(username + "@example.com")
                 .displayName("Test " + username)
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .roles(List.of("USER"))
                 .userToken(UUID.randomUUID())
                 .build();

--- a/comic-api/src/test/java/org/stapledon/infrastructure/config/UserConfigWriterTest.java
+++ b/comic-api/src/test/java/org/stapledon/infrastructure/config/UserConfigWriterTest.java
@@ -10,16 +10,16 @@ import org.stapledon.api.dto.user.User;
 import org.stapledon.api.dto.user.UserConfig;
 import org.stapledon.api.dto.user.UserRegistrationDto;
 import org.stapledon.common.config.CacheProperties;
+import org.stapledon.common.util.GsonUtils;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -122,7 +122,7 @@ class UserConfigWriterTest {
                             .displayName(user.getDisplayName())
                             .roles(user.getRoles())
                             .created(user.getCreated())
-                            .lastLogin(LocalDateTime.now())
+                            .lastLogin(OffsetDateTime.now())
                             .passwordHash(user.getPasswordHash())
                             .userToken(user.getUserToken())
                             .build();
@@ -144,7 +144,7 @@ class UserConfigWriterTest {
                     .email(registration.getEmail())
                     .displayName(registration.getDisplayName())
                     .passwordHash(BCrypt.hashpw(registration.getPassword(), BCrypt.gensalt()))
-                    .created(LocalDateTime.now())
+                    .created(OffsetDateTime.now())
                     .roles(List.of("USER"))
                     .userToken(UUID.randomUUID())
                     .build();
@@ -200,10 +200,7 @@ class UserConfigWriterTest {
 
     @BeforeEach
     void setUp() {
-        // Setup Gson with adapters for LocalDateTime
-        gson = new GsonBuilder()
-                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
-                .create();
+        gson = GsonUtils.createGson();
 
         // Create the test writer
         userConfigWriter = new TestUserConfigWriter(gson, tempDir);
@@ -437,7 +434,7 @@ class UserConfigWriterTest {
                 .email("test@example.com")
                 .displayName("Test User")
                 .roles(List.of("USER"))
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .build();
 
         User adminUser = User.builder()
@@ -446,7 +443,7 @@ class UserConfigWriterTest {
                 .email("admin@example.com")
                 .displayName("Admin User")
                 .roles(List.of("USER", "ADMIN"))
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .build();
 
         validConfig.getUsers().put("testuser", testUser);
@@ -666,21 +663,9 @@ class UserConfigWriterTest {
                 .passwordHash(BCrypt.hashpw("testpass", BCrypt.gensalt()))
                 .email(username + "@example.com")
                 .displayName("Test " + username)
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .roles(List.of("USER"))
                 .build();
     }
 
-    // Simple adapter for LocalDateTime serialization
-    static class LocalDateTimeAdapter implements com.google.gson.JsonSerializer<LocalDateTime>, com.google.gson.JsonDeserializer<LocalDateTime> {
-        @Override
-        public com.google.gson.JsonElement serialize(LocalDateTime src, java.lang.reflect.Type typeOfSrc, com.google.gson.JsonSerializationContext context) {
-            return new com.google.gson.JsonPrimitive(src.toString());
-        }
-
-        @Override
-        public LocalDateTime deserialize(com.google.gson.JsonElement json, java.lang.reflect.Type typeOfT, com.google.gson.JsonDeserializationContext context) throws com.google.gson.JsonParseException {
-            return LocalDateTime.parse(json.getAsString());
-        }
-    }
 }

--- a/comic-api/src/test/java/org/stapledon/infrastructure/security/JwtTokenUtilTest.java
+++ b/comic-api/src/test/java/org/stapledon/infrastructure/security/JwtTokenUtilTest.java
@@ -11,7 +11,7 @@ import org.stapledon.api.dto.auth.JwtTokenDto;
 import org.stapledon.api.dto.user.User;
 import org.stapledon.infrastructure.config.properties.JwtProperties;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -172,7 +172,7 @@ class JwtTokenUtilTest {
                 .passwordHash("hashedPassword")
                 .email(username + "@example.com")
                 .displayName("Test " + username)
-                .created(LocalDateTime.now())
+                .created(OffsetDateTime.now())
                 .roles(List.of("USER"))
                 .userToken(UUID.randomUUID())
                 .build();

--- a/comic-common/src/main/java/org/stapledon/common/dto/ComicConfig.java
+++ b/comic-common/src/main/java/org/stapledon/common/dto/ComicConfig.java
@@ -1,7 +1,5 @@
 package org.stapledon.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -18,24 +16,15 @@ public class ComicConfig {
     @ToString.Include
     private Map<Integer, ComicItem> items;
 
-    private List<ComicItem> comics;
+    // Transient so Gson skips this field during serialization. The items map is the single source
+    // of truth; comics is a derived view exposed by the getter for callers.
+    private transient List<ComicItem> comics;
 
     public ComicConfig() {
         this.items = new ConcurrentHashMap<>();
         this.comics = new ArrayList<>();
     }
 
-    /**
-     * Gets all comics as a list.
-     * If the comics list is empty but items map has values, populates the comics
-     * list from the items map.
-     * This method is marked with @JsonIgnore to prevent serialization of the comics
-     * array,
-     * ensuring only the items map is persisted (single source of truth).
-     *
-     * @return List of comic items
-     */
-    @JsonIgnore
     public List<ComicItem> getComics() {
         if (comics == null) {
             comics = new ArrayList<>();

--- a/comic-common/src/main/java/org/stapledon/common/dto/ComicNavigationResult.java
+++ b/comic-common/src/main/java/org/stapledon/common/dto/ComicNavigationResult.java
@@ -1,7 +1,5 @@
 package org.stapledon.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
@@ -44,26 +42,22 @@ public class ComicNavigationResult {
     /**
      * The date that was requested
      */
-    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate requestedDate;
 
     /**
      * Nearest available date going backward from the requested date (null if none)
      */
-    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate nearestPreviousDate;
 
     /**
      * Nearest available date going forward from the requested date (null if none)
      */
-    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate nearestNextDate;
 
     /**
      * The date of the current image being displayed (same as image.imageDate when
      * found)
      */
-    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate currentDate;
 
     /**

--- a/comic-common/src/main/java/org/stapledon/common/dto/ImageDto.java
+++ b/comic-common/src/main/java/org/stapledon/common/dto/ImageDto.java
@@ -1,7 +1,5 @@
 package org.stapledon.common.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
@@ -29,7 +27,6 @@ public class ImageDto {
     @ToString.Include
     Integer width;
 
-    @JsonFormat(pattern = "yyyy-MM-dd")
     @ToString.Include
     LocalDate imageDate;
 

--- a/comic-common/src/main/java/org/stapledon/common/util/GsonUtils.java
+++ b/comic-common/src/main/java/org/stapledon/common/util/GsonUtils.java
@@ -12,7 +12,9 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public final class GsonUtils {
     private GsonUtils() {
@@ -79,6 +81,15 @@ public final class GsonUtils {
         }
     }
 
+    /**
+     * Read/write adapter for {@link LocalDateTime}.
+     *
+     * <p>Retained for backward compatibility with persisted JSON written before the migration
+     * to {@link OffsetDateTime}. New code must use {@link OffsetDateTime} or {@link java.time.Instant}
+     * (see CLAUDE.md "Time Handling Rules"). Once all on-disk JSON has been rewritten with offset
+     * timestamps, this adapter and its registration can be removed.
+     */
+    @Deprecated(since = "tech-debt-cleanup", forRemoval = true)
     public static class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
         private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
@@ -121,7 +132,14 @@ public final class GsonUtils {
                 return null;
             }
             String dateTimeStr = jsonReader.nextString();
-            return OffsetDateTime.parse(dateTimeStr, FORMATTER);
+            try {
+                return OffsetDateTime.parse(dateTimeStr, FORMATTER);
+            } catch (DateTimeParseException ex) {
+                // Legacy JSON written before the OffsetDateTime migration stored ISO_LOCAL_DATE_TIME
+                // (no offset). Promote those to UTC on read; new writes always include the offset.
+                return LocalDateTime.parse(dateTimeStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                        .atOffset(ZoneOffset.UTC);
+            }
         }
     }
 }

--- a/comic-engine/src/main/java/org/stapledon/engine/batch/JsonBatchExecutionTracker.java
+++ b/comic-engine/src/main/java/org/stapledon/engine/batch/JsonBatchExecutionTracker.java
@@ -20,6 +20,8 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,11 +43,16 @@ import org.stapledon.engine.batch.dto.BatchStepSummary;
  * history tracking.
  * Implements JobExecutionListener to automatically export after each job
  * completion.
- * Uses gsonWithLocalDate bean for proper LocalDateTime serialization.
+ * Uses gsonWithLocalDate bean for proper OffsetDateTime serialization.
  *
  * <p>Stores a capped list of executions per job (configurable via
  * {@code batch.tracking.max-history-per-job}). Handles migration from
  * the legacy single-entry format automatically on read.
+ *
+ * <p>Spring Batch returns {@link LocalDateTime} from {@code JobExecution} and
+ * {@code StepExecution}. Per CLAUDE.md, those values are converted to
+ * {@link OffsetDateTime} at this boundary using the configured
+ * {@code batch.timezone} so persisted data carries an explicit offset.
  */
 @Slf4j
 @Component
@@ -54,6 +61,7 @@ public class JsonBatchExecutionTracker extends LoggingJobExecutionListener imple
     private final CacheProperties cacheProperties;
     private final Gson gson;
     private final int maxHistoryPerJob;
+    private final ZoneId batchZone;
     private final ConcurrentHashMap<Long, Long> h2ToStableId = new ConcurrentHashMap<>();
 
     private static final String BATCH_EXECUTIONS_FILENAME = "batch-executions.json";
@@ -67,10 +75,19 @@ public class JsonBatchExecutionTracker extends LoggingJobExecutionListener imple
     public JsonBatchExecutionTracker(
             CacheProperties cacheProperties,
             @Qualifier("gsonWithLocalDate") Gson gson,
-            @Value("${batch.tracking.max-history-per-job:30}") int maxHistoryPerJob) {
+            @Value("${batch.tracking.max-history-per-job:30}") int maxHistoryPerJob,
+            @Value("${batch.timezone:UTC}") String batchTimezone) {
         this.cacheProperties = cacheProperties;
         this.gson = gson;
         this.maxHistoryPerJob = maxHistoryPerJob;
+        this.batchZone = ZoneId.of(batchTimezone);
+    }
+
+    private OffsetDateTime toOffset(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+        return localDateTime.atZone(batchZone).toOffsetDateTime();
     }
 
     @Override
@@ -93,7 +110,7 @@ public class JsonBatchExecutionTracker extends LoggingJobExecutionListener imple
                     .executionId(stableId)
                     .jobName(jobName)
                     .status(BatchStatus.STARTED.name())
-                    .startTime(jobExecution.getStartTime())
+                    .startTime(toOffset(jobExecution.getStartTime()))
                     .build();
 
             Map<String, List<BatchExecutionSummary>> executions = readExecutions();
@@ -209,19 +226,19 @@ public class JsonBatchExecutionTracker extends LoggingJobExecutionListener imple
                         (int) step.getSkipCount(),
                         (int) step.getCommitCount(),
                         (int) step.getRollbackCount(),
-                        step.getStartTime(),
-                        step.getEndTime()))
+                        toOffset(step.getStartTime()),
+                        toOffset(step.getEndTime())))
                 .toList();
 
         BatchExecutionSummary summary = BatchExecutionSummary.builder()
                 .executionId(effectiveId)
                 .jobName(jobName)
-                .executionTime(jobExecution.getEndTime())
+                .executionTime(toOffset(jobExecution.getEndTime()))
                 .status(jobExecution.getStatus().name())
                 .exitCode(jobExecution.getExitStatus().getExitCode())
                 .exitMessage(jobExecution.getExitStatus().getExitDescription())
-                .startTime(jobExecution.getStartTime())
-                .endTime(jobExecution.getEndTime())
+                .startTime(toOffset(jobExecution.getStartTime()))
+                .endTime(toOffset(jobExecution.getEndTime()))
                 .parameters(params)
                 .steps(steps)
                 .build();
@@ -427,7 +444,7 @@ public class JsonBatchExecutionTracker extends LoggingJobExecutionListener imple
     /**
      * Checks if a job has run since the specified time.
      */
-    public boolean hasJobRunSince(String jobName, LocalDateTime since) {
+    public boolean hasJobRunSince(String jobName, OffsetDateTime since) {
         return getLastExecution(jobName)
                 .filter(summary -> summary.getEndTime() != null)
                 .filter(summary -> summary.getEndTime().isAfter(since))

--- a/comic-engine/src/main/java/org/stapledon/engine/batch/dto/BatchExecutionSummary.java
+++ b/comic-engine/src/main/java/org/stapledon/engine/batch/dto/BatchExecutionSummary.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -26,7 +26,7 @@ public class BatchExecutionSummary {
     @ToString.Include
     String jobName;
     @ToString.Include
-    LocalDateTime executionTime;
+    OffsetDateTime executionTime;
     @ToString.Include
     String status;
     @ToString.Include
@@ -34,9 +34,9 @@ public class BatchExecutionSummary {
     @ToString.Include
     String exitMessage;
     @ToString.Include
-    LocalDateTime startTime;
+    OffsetDateTime startTime;
     @ToString.Include
-    LocalDateTime endTime;
+    OffsetDateTime endTime;
     @ToString.Include
     String errorMessage;
     String logFileName;

--- a/comic-engine/src/main/java/org/stapledon/engine/batch/dto/BatchStepSummary.java
+++ b/comic-engine/src/main/java/org/stapledon/engine/batch/dto/BatchStepSummary.java
@@ -1,6 +1,6 @@
 package org.stapledon.engine.batch.dto;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 /**
  * Summary of a single batch step execution, persisted to JSON.
@@ -14,7 +14,7 @@ public record BatchStepSummary(
         int skipCount,
         int commitCount,
         int rollbackCount,
-        LocalDateTime startTime,
-        LocalDateTime endTime
+        OffsetDateTime startTime,
+        OffsetDateTime endTime
 ) {
 }

--- a/comic-engine/src/main/java/org/stapledon/engine/batch/scheduler/SchedulerStateService.java
+++ b/comic-engine/src/main/java/org/stapledon/engine/batch/scheduler/SchedulerStateService.java
@@ -12,7 +12,8 @@ import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +57,7 @@ public class SchedulerStateService {
      * Sets the paused state for a job and persists the change.
      */
     public void setPaused(String jobName, boolean paused, String username) {
-        var state = new SchedulerState(paused, LocalDateTime.now(), username);
+        var state = new SchedulerState(paused, OffsetDateTime.now(ZoneOffset.UTC), username);
         states.put(jobName, state);
         persistStates();
         log.info("Job {} {} by {}", jobName, paused ? "paused" : "resumed", username);
@@ -118,6 +119,6 @@ public class SchedulerStateService {
     /**
      * Represents the pause/resume state for a single job scheduler.
      */
-    public record SchedulerState(boolean paused, LocalDateTime lastToggled, String toggledBy) {
+    public record SchedulerState(boolean paused, OffsetDateTime lastToggled, String toggledBy) {
     }
 }

--- a/comic-engine/src/main/java/org/stapledon/engine/downloader/ComicDownloaderFacade.java
+++ b/comic-engine/src/main/java/org/stapledon/engine/downloader/ComicDownloaderFacade.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class ComicDownloaderFacade implements DownloaderFacade {
      */
     @Override
     public ComicDownloadResult downloadComic(ComicDownloadRequest request) {
-        LocalDateTime startTime = LocalDateTime.now();
+        Instant startTime = Instant.now();
 
         // Validate request has a source
         if (request.getSource() == null || request.getSource().isEmpty()) {
@@ -197,7 +197,7 @@ public class ComicDownloaderFacade implements DownloaderFacade {
      */
     @Override
     public ComicDownloadResult downloadLatestStrip(ComicItem comic) {
-        LocalDateTime startTime = LocalDateTime.now();
+        Instant startTime = Instant.now();
         ComicDownloaderStrategy strategy = downloaderStrategies.get(comic.getSource());
 
         if (!(strategy instanceof IndexedComicDownloaderStrategy indexed)) {
@@ -236,7 +236,7 @@ public class ComicDownloaderFacade implements DownloaderFacade {
      */
     @Override
     public ComicDownloadResult downloadStrip(ComicItem comic, int stripNumber) {
-        LocalDateTime startTime = LocalDateTime.now();
+        Instant startTime = Instant.now();
         ComicDownloaderStrategy strategy = downloaderStrategies.get(comic.getSource());
 
         if (!(strategy instanceof IndexedComicDownloaderStrategy indexed)) {
@@ -319,8 +319,8 @@ public class ComicDownloaderFacade implements DownloaderFacade {
         }
     }
 
-    private void recordSuccess(ComicDownloadRequest request, LocalDateTime startTime, long imageSize) {
-        long durationMs = Duration.between(startTime, LocalDateTime.now()).toMillis();
+    private void recordSuccess(ComicDownloadRequest request, Instant startTime, long imageSize) {
+        long durationMs = Duration.between(startTime, Instant.now()).toMillis();
 
         ComicRetrievalRecord record = ComicRetrievalRecord.success(
                 request.getComicName(),
@@ -339,10 +339,10 @@ public class ComicDownloaderFacade implements DownloaderFacade {
             ComicDownloadRequest request,
             ComicRetrievalStatus status,
             String errorMessage,
-            LocalDateTime startTime,
+            Instant startTime,
             Integer httpStatusCode) {
 
-        long durationMs = Duration.between(startTime, LocalDateTime.now()).toMillis();
+        long durationMs = Duration.between(startTime, Instant.now()).toMillis();
 
         ComicRetrievalRecord record = ComicRetrievalRecord.failure(
                 request.getComicName(),

--- a/comic-engine/src/test/java/org/stapledon/engine/batch/JsonBatchExecutionTrackerTest.java
+++ b/comic-engine/src/test/java/org/stapledon/engine/batch/JsonBatchExecutionTrackerTest.java
@@ -17,20 +17,15 @@ import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.step.StepExecution;
 import org.stapledon.common.config.CacheProperties;
+import org.stapledon.common.util.GsonUtils;
 import org.stapledon.engine.batch.dto.BatchExecutionSummary;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,12 +44,9 @@ class JsonBatchExecutionTrackerTest {
         cacheProperties = mock(CacheProperties.class);
         when(cacheProperties.getLocation()).thenReturn(tempDir.toString());
 
-        gson = new GsonBuilder()
-                .setPrettyPrinting()
-                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
-                .create();
+        gson = GsonUtils.createGson();
 
-        tracker = new JsonBatchExecutionTracker(cacheProperties, gson, 5);
+        tracker = new JsonBatchExecutionTracker(cacheProperties, gson, 5, "America/Toronto");
     }
 
     @Test
@@ -212,7 +204,7 @@ class JsonBatchExecutionTrackerTest {
 
     @Test
     void hasJobRunSinceReturnsTrueWhenJobRanAfterThreshold() {
-        LocalDateTime threshold = LocalDateTime.now().minusHours(2);
+        OffsetDateTime threshold = OffsetDateTime.now().minusHours(2);
         JobExecution execution = createJobExecutionWithTimes("TestJob", 1L,
                 LocalDateTime.now().minusHours(1), LocalDateTime.now().minusMinutes(30));
 
@@ -366,7 +358,7 @@ class JsonBatchExecutionTrackerTest {
         assertThat(tracker.getLastExecution("TestJob").orElseThrow().getExecutionId()).isEqualTo(1L);
 
         // Simulate restart: new tracker instance, same JSON file
-        var tracker2 = new JsonBatchExecutionTracker(cacheProperties, gson, 5);
+        var tracker2 = new JsonBatchExecutionTracker(cacheProperties, gson, 5, "America/Toronto");
         // H2 would restart from 1, but stable ID should continue from 2
         tracker2.afterJob(createJobExecution("TestJob", 1L, BatchStatus.COMPLETED));
 
@@ -443,28 +435,4 @@ class JsonBatchExecutionTrackerTest {
         return execution;
     }
 
-    /**
-     * LocalDateTime adapter matching the production GsonProvider configuration.
-     */
-    static class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
-        private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
-        @Override
-        public void write(JsonWriter jsonWriter, LocalDateTime localDateTime) throws IOException {
-            if (localDateTime == null) {
-                jsonWriter.nullValue();
-            } else {
-                jsonWriter.value(FORMATTER.format(localDateTime));
-            }
-        }
-
-        @Override
-        public LocalDateTime read(JsonReader jsonReader) throws IOException {
-            if (jsonReader.peek() == JsonToken.NULL) {
-                jsonReader.nextNull();
-                return null;
-            }
-            return LocalDateTime.parse(jsonReader.nextString(), FORMATTER);
-        }
-    }
 }

--- a/comic-hub/package-lock.json
+++ b/comic-hub/package-lock.json
@@ -43,7 +43,6 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3017,85 +3016,6 @@
         }
       }
     },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -5320,13 +5240,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -5967,79 +5880,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^30.0.0",
-        "pretty-format": "^30.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@types/jest/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/js-cookie": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
@@ -6100,13 +5940,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
@@ -6137,23 +5970,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",
@@ -7720,22 +7536,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -9400,24 +9200,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.3.0",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -11452,207 +11234,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-diff/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.3.0",
-        "pretty-format": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "jest-util": "30.3.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jiti": {
@@ -15112,29 +14693,6 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/comic-hub/package.json
+++ b/comic-hub/package.json
@@ -52,7 +52,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -65,10 +65,11 @@ REST + GraphQL API layer. Depends on all three backend modules.
 
 | Area | Key Classes |
 |------|-------------|
-| Controllers | `ComicController`, `UpdateController`, `BatchJobController` |
-| Services | `UpdateService`, `RetrievalStatusServiceImpl`, `AuthService`, `UserService`, `PreferenceService` |
-| Repositories | `ComicRepository`, `UserRepository`, `PreferenceRepository` |
-| Security | JWT-based authentication with `AuthService` |
+| GraphQL Resolvers | `AuthResolver`, `BatchJobResolver`, `ComicResolver`, `HealthResolver`, `MetricsResolver`, `PreferenceResolver`, `RetrievalResolver`, `UserResolver` (plus dataloaders and type resolvers in `api/resolver/`) |
+| REST Controllers | `ComicController` (binary image streaming only) |
+| Services | `UpdateService` / `ComicUpdateService`, `JsonRetrievalStatusService`, `AuthService` / `JwtAuthService`, `UserService` / `JsonUserService`, `PreferenceService` / `JsonPreferenceService`, `HealthService`, `SystemHealthService` |
+| Repositories | `JsonComicRepository`, `JsonUserRepository`, `JsonPreferenceRepository` (under `infrastructure/repository/`) |
+| Security | JWT-based authentication via `JwtAuthService` |
 
 ### comic-hub
 


### PR DESCRIPTION
Documentation
- Drop deleted comic-web (Angular) module from architecture diagram and edges in CLAUDE.md
- Remove broken docs/2026-ui-refactor reference (folder never existed)
- Fix STORAGE_DETAILS.md reference in comic-api/CLAUDE.md to actual storage docs
- Refresh stale controller list in docs/design/architecture.md (only ComicController remains; rest moved to GraphQL resolvers)
- Update Gson policy in comic-api/CLAUDE.md to reflect actual rule: Gson for persisted JSON, Jackson allowed at Spring framework boundaries

Jackson → Gson (domain DTOs)
- ComicConfig: @JsonIgnore on getter → transient field
- ImageDto, ComicNavigationResult: @JsonFormat removed (LocalDateAdapter handles ISO date)
- Health DTOs and ApiResponse keep Jackson (Spring actuator/REST boundary)
- GsonProvider consolidates onto GsonUtils.createGsonBuilder() — removes ~120 lines of duplicated TypeAdapter code

LocalDateTime → OffsetDateTime / Instant
- User.created/lastLogin, ApiResponse.timestamp, HealthStatus.timestamp now OffsetDateTime
- BatchExecutionSummary, BatchStepSummary, SchedulerState.lastToggled now OffsetDateTime; conversion happens at the Spring Batch boundary in JsonBatchExecutionTracker using configured batch.timezone (per CLAUDE.md time-handling rule)
- ComicDownloaderFacade timing now uses Instant for monotonic elapsed-time math
- OffsetDateTimeAdapter tolerates legacy offset-less ISO strings (promotes to UTC) so existing on-disk JSON keeps loading
- LocalDateTimeAdapter marked @Deprecated; removable once all persisted timestamps are rewritten with offsets

Infrastructure
- comic-api/Dockerfile: install wget so HEALTHCHECK actually works on Alpine
- Rename .github/workflows/angular.yml → comic-hub.yml; drop hardcoded internal LAN IP from build env

Frontend
- Remove unused @types/jest devDep (Vitest is the runner; jest-dom matchers ship their own types)