### PR TITLE
Fix comic-hub/build-docker.sh to cd into its own directory

### DIFF
--- a/comic-hub/build-docker.sh
+++ b/comic-hub/build-docker.sh
@@ -26,6 +26,9 @@ echo "${BUILD_TAG}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$' || {
 }
 
 # 1. Build the Docker image locally with the tag
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${SCRIPT_DIR}"
+
 FULL_IMAGE="${DOCKER_REGISTRY}/${IMAGE_NAME}:${BUILD_TAG}"
 echo "--- Building ${FULL_IMAGE} ---"
 docker build -f Dockerfile . --tag "${FULL_IMAGE}" --platform linux/amd64


### PR DESCRIPTION
## Summary

`comic-hub/build-docker.sh` runs `docker build -f Dockerfile .` without first cd-ing into its own directory. When invoked from any other cwd, Docker resolves `Dockerfile` against the caller's cwd and fails with:

```
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /Users/agilbert/git/ComicCacher/utils/Dockerfile: no such file or directory
```

This was hit by the new `utils/prod-build-and-run.sh` (#273) running the hub builder from `utils/` cwd. The api builder (`comic-api/build-docker.sh:35`) avoids this by explicitly `cd "${SCRIPT_DIR}"` before `docker build` — this PR mirrors that pattern.

## Why this was latent

The hub builder was previously only invoked manually with `cd comic-hub && ./build-docker.sh <ver>`, so the cwd was always correct. The dev deploy script (`utils/dev-build-and-run.sh`) only invokes the api builder, never the hub one. The new prod script invokes both — exposing the bug.

## Audit

Sibling scripts checked for the same anti-pattern:
- `comic-api/build-docker.sh` — already cd's correctly (line 35). No change needed.
- `utils/dev-build-and-run.sh` — only calls api builder; uses absolute paths elsewhere. OK.
- `utils/prod-build-and-run.sh` — uses absolute paths and the cwd-safe builders. OK after this fix.

## Test plan

- [x] `bash -n comic-hub/build-docker.sh` — clean
- [ ] Re-run `./utils/prod-build-and-run.sh --api 2.4.5 --ui 2.4.5` from `utils/` cwd; ui build now succeeds
- [ ] Manual `./comic-hub/build-docker.sh 2.4.5` from repo root and from `comic-hub/` — both still work