### PR TITLE
Healthcheck: probe 127.0.0.1 instead of localhost (busybox wget IPv6 quirk)

### DIFF
--- a/comic-hub/Dockerfile
+++ b/comic-hub/Dockerfile
@@ -37,7 +37,10 @@ ENV HOSTNAME=0.0.0.0
 
 EXPOSE 8080
 
+# Use 127.0.0.1 explicitly: alpine's busybox wget resolves `localhost` to ::1
+# (IPv6) first per /etc/hosts and does not fall back to IPv4, so it gets
+# Connection refused against our IPv4-only bind on 0.0.0.0.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s \
-  CMD wget -q --spider http://localhost:8080/api/health || exit 1
+  CMD wget -q --spider http://127.0.0.1:8080/api/health || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

Follow-up to #276. After that PR landed, Next.js correctly binds on `0.0.0.0:8080` — but the comic-hub container *still* reports `unhealthy` because alpine's busybox `wget` resolves `localhost` to `::1` (IPv6) first and does **not** fall back to IPv4.

This PR swaps the HEALTHCHECK URL from `localhost` to `127.0.0.1`.

## Root cause (verified on prod with #276 deployed)

```
$ docker --context portainer exec comics-ui getent hosts localhost
::1               localhost  localhost
```

Alpine's `/etc/hosts` lists both:
- `127.0.0.1  localhost`
- `::1        localhost ip6-localhost ip6-loopback`

busybox wget picks the first match — `::1` — and tries `[::1]:8080`. Next.js bound via `HOSTNAME=0.0.0.0` is IPv4-wildcard only, so the IPv6 attempt gets Connection refused, and busybox `wget` does not retry on IPv4. Verified inside the running container:

```
wget http://127.0.0.1:8080/api/health → 200 {"status":"ok"}
wget http://[::1]:8080/api/health     → Connection refused
wget http://localhost:8080/api/health → resolves to ::1 → Connection refused
```

## Fix

```dockerfile
HEALTHCHECK --interval=30s --timeout=3s --start-period=30s \
  CMD wget -q --spider http://127.0.0.1:8080/api/health || exit 1
```

Plus a comment in the Dockerfile explaining the busybox wget quirk so the next person doesn't change it back.

## Why this slipped past #275 + #276

#275 introduced the probe (`/api/health`) and #276 fixed the bind. Neither was wrong — but together they only got the server listening on IPv4. The probe URL was the third leg of the same problem, surfaced only by inspecting the running container post-#276 deploy.

## Audit of related code

- `comic-api/Dockerfile:15` — `wget --spider http://localhost:8888/actuator/health`. Same potential hazard, but Spring Boot binds dual-stack on the JVM by default, so connections to `[::1]:8888` succeed. Probe currently works. Switching to `127.0.0.1` would remove the implicit dual-stack assumption — defensive cleanup candidate, **not in this PR**.

## Changes by area

### Container
- `comic-hub/Dockerfile` — HEALTHCHECK URL `localhost` → `127.0.0.1`, with explanatory comment.

## Test plan

- [x] Inside running comics-ui (post-#276): `wget http://127.0.0.1:8080/api/health` returns 200 `{"status":"ok"}`.
- [ ] Build & deploy via `utils/prod-build-and-run.sh --ui <tag>`; confirm comics-ui flips `healthy` within the first 30s interval.